### PR TITLE
css to emphasize h1 headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata

--- a/style.css
+++ b/style.css
@@ -1,0 +1,19 @@
+
+
+#header {
+  margin-bottom: 75px;
+}
+
+h1:not(:first-child) {
+  margin-top: 60px;
+  margin-bottom: 20px;
+  border-bottom: 1px solid #CCC;
+  float: left;
+  width: 100%;
+  padding-bottom: 3px;
+  font-weight: bold;
+}
+
+h2 {
+  margin-top: 40px;
+}


### PR DESCRIPTION
Goal: to make it easier for the student to distinguish important sections / natural breaks in the lab document. 

I included a css file in the root directory that 

1. adds lots of vertical space around h1 and h2 section headers (except the document title),
2. adds a grey horizontal rule to h1 headers, and 
3. increases vertical space after the header div (title, author, date, etc.).

The file is located in the root directory and can be added to the output part of the yaml of each Rmarkdown with `css: "../style.css"`.