### PR TITLE
lab 09 edits

### DIFF
--- a/09 Point pattern analysis/GEOG_6000_Lab_09_Point_Patterns.Rmd
+++ b/09 Point pattern analysis/GEOG_6000_Lab_09_Point_Patterns.Rmd
@@ -8,13 +8,16 @@ output:
     toc_float: true
     fig_caption: true
     css: "../style.css"
-header-includes:
-   - \usepackage{tabularx}
 ---
 
 ```{r echo=FALSE}
-options(width=50)
+
+# center all figures
+knitr::opts_chunk$set(fig.align = "center")
+
+# seed
 set.seed(1234)
+
 ```
 
 In this lab, we will carry out some point pattern data analysis. We will cover constructing point pattern objects, basic data exploration and building simple models. 
@@ -38,94 +41,134 @@ install.packages(pkgs)
 
 ```
 
-\newpage
+# Point pattern data
 
-## Reading and plotting point pattern data
+For most of this lab we will use the 'BEI' data set, in the file *bei.csv*. This is a set of locations of 3605 trees in a tropical rainforest taken from Barro Colorado Island, Panama. All analysis of this data will be done using functions taken from the `spatstat` package, so start by loading this package. 
 
-For most of this lab we will use the 'BEI' data set, in the file *bei.csv*. This is set of locations of 3605 trees in a tropical rainforest taken from Barro Colorado Island, Panama. All analysis of this data will be done using functions taken from the \textbf{spatstat} package, so start by loading this package. 
 ```{r message=FALSE}
+
 library(spatstat)
+
 ```
 
 Prior to all analysis, the locations must be read in and stored in a point pattern object (`ppp`). These objects contain, at minimum, the locations of the objects and a description of the window delimiting the study area (either as a box or a polygon). To create this for the BEI dataset, we (1) read in the data; (2) check the range of coordinates (with the `summary()` function);  (3) create a bounding window using the `owin()` function; (3) create the `ppp` object with the X and Y coordinates and the window:
+
 ```{r}
+
 bei <- read.csv("../datafiles/bei.csv")
+
 summary(bei)
+
 bei.owin <- owin(xrange = c(0,1000), yrange = c(0,500))
+
 bei.ppp <- ppp(bei$x, bei$y, window = bei.owin)
+
 ```
 
 We can use `plot()` and `summary()` functions; these will adapt to the point process object.
+
 ```{r}
+
 plot(bei.ppp, pch = 16, cols = 'gray')
+
 summary(bei.ppp)
+
 ```
 
 Note that the `summary()` function returns the average intensity or number of objects (trees) per unit area.
  
-## Quadrat counts and tests
+# Quadrat counts and tests
 
 As the distribution of the trees is clearly non-uniform or inhomogenous, we require different methods to assess how this distribution varies over space. The simplest method is to divide the area into *quadrats* and count the number of trees per quadrat. The parameters `nx` and `ny` define the number of quadrats along each coordinate.
 
-```{r fig.keep='high'}
+```{r}
+
 bei.qc <- quadratcount(bei.ppp, nx = 6, ny = 3)
+
 plot(bei.qc)
+
 ```
 
-We can test for a significant departure from a uniform or homogenous distribution by using the function `quadrat.test()`. This compares the observed number against an expected number if the objects were distributed uniformly (number of trees / number of quadrats). The differences are used in a Chi-squared test, with the null hypothesis of homogenous or equal distribution among the transects.
-```{r fig.keep='high', results='hide'}
+We can test for a significant departure from a uniform or homogenous distribution by using the function `quadrat.test()`. This compares the observed number against an expected number if the objects were distributed uniformly (number of trees / number of quadrats). The differences are used in a Chi-squared test, with the null hypothesis of homogeneity or equal distribution among the transects.
+
+```{r}
+
 bei.qt <- quadrat.test(bei.ppp, nx = 6, ny = 3)
+
 bei.qt
+
 plot(bei.qt, cex=0.8)
+
 ```
 
-The $p$-value obtained suggests that we can reject the null hypothesis, and accept the alternative, that there is a non-homogenous distribution, which implies that there is some spatial process controlling the distribution of the trees. 
+The $p$-value obtained suggests that we can reject the null hypothesis, and accept the alternative, that there is a inhomogenous distribution, which implies that there is some spatial process controlling the distribution of the trees. 
 
 As an alternative to the simple quadrat approach, we can use a covariate to see if there is an association between values of the covariate and the object distribution. Here we use gridded slope values for the study area, contained in the file `beislope.csv`, read into R as a pixel image object. In order for this to be used, we (1) read in the gridded dataset; (2) create a new window for the gridded data (on a 10m grid); (3) create the pixel object using the `as.im()` function. Note that we define the window size by hand by specifying minimum and maximum `x` and `y` coordinates of the region.
 
-```{r fig.keep='high'}
+```{r}
+
 bei.slope <- read.csv("../datafiles/beislope.csv", header = FALSE)
+
 bei.slope.owin <- owin(xrange = c(-2.5, 1002.5), yrange = c(-2.5, 502.5))
+
 bei.slope <- as.im(as.matrix(bei.slope), W = bei.slope.owin)
+
 plot(bei.slope)
+
 plot(bei.ppp, pch = 16, cex = 0.7, add = TRUE)
+
 ```
 
 To use the quadrat method with this data, we need to convert the slope into slope classes, then check for association with each class. We start be creating the classes: (1) calculate quartiles of slope values for the class boundaries; (2) use the `cut()` function to assign slope values to one of the four classes; (3) create a tessellation based on the classes, which will be used to identify which class a object belongs to (using the `tess()` function):
 
-```{r fig.keep='high'}
-b <- quantile(bei.slope, probs = seq(0,1,by=0.25))
+```{r}
+
+b <- quantile(bei.slope, probs = seq(0,1, by = 0.25))
+
 bei.slope.cut <- cut(bei.slope, breaks = b, labels = 1:4)
+
 bei.slope.tess <- tess(image = bei.slope.cut)
+
 plot(bei.slope.tess, valuesAreColours=FALSE)
+
 plot(bei.ppp, add = TRUE, pch = "+")
+
 ```
 
 Now we can use the `quadratcount()` function, but use the tessellation, rather than a set number of grid boxes. 
 
-```{r fig.keep='high'}
+```{r}
+
 qb <- quadratcount(bei.ppp, tess = bei.slope.tess)
+
 plot(qb, valuesAreColours=FALSE)
+
 ```
 
 Finally, we can test for to see if the objects are preferentially clustered in the slope classes using the `quadrat.test()` function. Again, we test against a null hypothesis that the distribution should be equal across all classes:
 
-```{r fig.keep='high', results='hide'}
+```{r}
+
 bei.qt <- quadrat.test(bei.ppp, tess = bei.slope.tess)
+
 bei.qt
-plot(bei.qt, cex  =0.8, valuesAreColours = FALSE)
+
+plot(bei.qt, cex = 0.8, valuesAreColours = FALSE)
+
 ```
 
-The low $p$-value again suggests that we can reject the null hypothesisma and state that the trees are not uniformly distributed across the slope classes. 
+The low $p$-value again suggests that we can reject the null hypothesis and state that the trees are not uniformly distributed across the slope classes. 
 
-## Kernel density functions
+# Kernel density functions
 
 Variations in the intensity of a spatial point process may also be investigated using a kernel density method. This fits two-dimensional Gaussian kernels (or windows) to the point objects, and effectively sums them across the area. Areas with higher densities of objects will therefore have a higher sum. These density functions provide a useful summary of variations in intensity and a good visualization method to examine a dataset for random or non-random distributions.
 
-The densities are calculated using the `density()` function, which adapts to a `ppp` object. The most important parameter is `sigma`, which control the bandwidth or size of the window fit to each point. 
+The densities are calculated using the `density()` function, which adapts to a `ppp` object. The most important parameter is `sigma`, which controls the bandwidth or size of the window fit to each point. 
 
 ```{r}
+
 plot(density(bei.ppp, sigma = 60))
+
 ```
 
 - Re-run this command with different values of `sigma` to see the effect of changing this parameter
@@ -133,44 +176,52 @@ plot(density(bei.ppp, sigma = 60))
 The bandwidth can be selected using cross validation. This can be done in a two step process by (1) selecting the bandwidth using `bw.diggle`, then using this in the density function. Note that this tends to give very conservative estimates of bandwidth:
 
 ```{r}
+
 bei.bw <- bw.diggle(bei.ppp)
+
 plot(density(bei.ppp, sigma = bei.bw))
+
 ```
 
-## Distance functions
+# Distance functions
 
 Distance functions can be used to investigate the interaction between points in space. Various methods exist, all based on the idea of calculating distances between points and other points, or fixed points in the study region. The most well-known of these is Ripley's $K$ function, which describes the distribution as the set of all pairwise distances between points. 
 
 We will run this using a different point data set, the redwoods data: *redwood.shp*. Read this into R, and create a point process object. As the data is in a shape file, we will need to use the `st_read()` function from the **sf** package. This package also includes a helper function `as.ppp()` to convert directly to a `ppp` object.  
 
-```{r fig.keep='high', message=FALSE}
+```{r, message=FALSE}
+
 library(sf)
-redwood.sf <- st_read("../datafiles/redwood/redwood.shp")
+
+redwood.sf <- st_read("../datafiles/redwood/redwood.shp", quiet = TRUE)
+
 redwood.ppp <- as.ppp(redwood.sf)
+
 redwood.ppp
-# redwood.sp <- readOGR("../datafiles/redwood/redwood.shp")
-# y <- as(redwood.sp, "SpatialPoints")
-# redwood <- as(y, "ppp")
-# redwood.owin <- owin(x = c(0, 1), y = c(0, 1))
-# redwood <- redwood[redwood.owin]
-# plot(redwood)
+
 ```
 
 The function has created a `ppp` object, but by default it uses the first column in the `sf` data frame as a *mark*, a label on each point. We'll look at this later in the lab, but for now we want to ignore this by setting it to a NULL value. The other thing we'll correct is the window size, setting the minimum and maximum limits to 0 and 1 for both the $x$ and $y$ axes. 
-
 ```{r}
+
 marks(redwood.ppp) <- NULL
+
 Window(redwood.ppp) <- owin(x = c(0, 1), y = c(0, 1))
+
 plot(redwood.ppp)
+
 ```
 
-### Ripley's $K$
+## Ripley's $K$
 
-Ripley's $K$ function is calculated using the \texttt{Kest()} function and similar functions exist for the $F$ and $G$ functions. Once calculated, we can plot out the results, including the observed values of Ripley's $K$ and a theoretical curve based on an homogenous poisson process with an intensity equal to our point process object. 
+Ripley's $K$ function is calculated using the `Kest()` function and similar functions exist for the $F$ and $G$ functions. Once calculated, we can plot out the results, including the observed values of Ripley's $K$ and a theoretical curve based on an homogenous poisson process with an intensity equal to our point process object. 
 
-```{r fig.keep='high'}
+```{r}
+
 redwood.kest <- Kest(redwood.ppp)
+
 plot(redwood.kest)
+
 ```
 
 If the point process data is effectively random (i.e. follows a poisson distribution), we would expect the observed line (black) to fall on top of or close to the theoretical line (blue). Above the theoretical line indicates clustering; below indicates a regular or ordered distribution. The green and red line represent $K$ values calculated with different corrections for the border effect.
@@ -182,138 +233,275 @@ The redwood data appear to be clustered. To test if these are significantly diff
 3. The number of random simulations to be performed (99)
 
 ```{r}
-redwood.kest.mc <- envelope(redwood.ppp, fun = 'Kest', 
-                            nsim = 99, verbose = FALSE)
+
+redwood.kest.mc <- envelope(redwood.ppp, 
+                            fun = 'Kest', 
+                            nsim = 99, 
+                            verbose = FALSE)
+
 plot(redwood.kest.mc, shade = c("hi", "lo"))
+
 ```
 
 Note that this uses point-wise estimates of uncertainty, and cannot be used as a post-hoc test. A better approach is to calculate the global uncertainty as the largest deviation between the randomly generated values of $K$ and the theoretical value:
 
-```{r fig.keep='high'}
-redwood.kest.mc <- envelope(redwood.ppp, fun = 'Kest', 
-                            nsim = 99, verbose = FALSE, global = TRUE)
+```{r}
+
+redwood.kest.mc <- envelope(redwood.ppp, 
+                            fun = 'Kest', 
+                            nsim = 99, 
+                            verbose = FALSE, 
+                            global = TRUE)
+
 plot(redwood.kest.mc, shade = c("hi", "lo"))
+
 ```
 
-### Besag's $L$
+## Besag's $L$
 
 The $L$-function was proposed by Besag as a way to stabilize the variance of Ripley's $K$ and improve the interpretation. We can calculate this by simply replacing the function name in the `envelope()` function, as follows:
 
-```{r fig.keep='high'}
-redwood.lest.mc <- envelope(redwood.ppp, fun = 'Lest', 
-                            nsim = 99, verbose = FALSE, global = TRUE)
+```{r}
+
+redwood.lest.mc <- envelope(redwood.ppp, 
+                            fun = 'Lest', 
+                            nsim = 99, 
+                            verbose = FALSE, 
+                            global = TRUE)
+
 plot(redwood.lest.mc, shade = c("hi", "lo"))
+
 ```
 
 
-### Pair correlation function
+## Pair correlation function
 
 The final function we will look at here is the pair correlation function. Instead of using cumulative pairs of distances, this is based on the number of pairs of points seperated by a band of distances. This has the advantage of providing a clearer idea of the range of interactions - as Ripley's $K$ is based on the cumulative set of distances, this can make it seem as though interactions are present over greater distances than they really are. Again, we can use the `envelope()` function, but this time we remove the `global` option by setting it to false, as this is no longer needed. 
 
-```{r fig.keep='high'}
-redwood.pcf.mc <- envelope(redwood.ppp, fun = 'pcf', 
-                            nsim = 99, verbose = FALSE)
+```{r}
+
+redwood.pcf.mc <- envelope(redwood.ppp, 
+                           fun = 'pcf', 
+                           nsim = 99, 
+                           verbose = FALSE)
+
 plot(redwood.pcf.mc, shade=c("hi", "lo"), ylim = c(0,5))
+
 ```
 
 This shows positive interactions up to a range of about 0.07 map units, much less than in the corresponding $K$-function. 
 
-## Marked point processes
+# Marked point processes
 
 In the previous sections, the point processes have been considered as single objects. *Marked* point process data include some information that distinguish the objects into different classes, allowing study of the co-occurrence (either positive or negative) between different classes of object. The Lansing forest data set contains the location of a set of trees in a forest in Michigan. Read this file in and take a look at the structure of the data, and you will see there is a column defining the species name of each tree. 
 
 ```{r}
+
 lansing <- read.csv("../datafiles/lansing/lansing.csv")
+
 str(lansing)
+
 ```
 
 We'll now create a `ppp` object using the `species` to defined the *marks* or the labels of each point. Some differences from before: (1) the window describing the study area is in a shape file (*lansing.shp* and will need to be read in and converted to an `owin` object; (2) we need to specify the class information (the species names) when creating the `ppp` object, using the `marks` parameter. Note that we first need to convert this column to a `factor` so that R will recognize it as labels. 
 
-```{r fig.keep='high', message=FALSE, results='hide'}
+```{r, message = FALSE}
+
 lansing$species <- as.factor(lansing$species)
-lansing.win <- st_read("../datafiles/lansing/lansing.shp")
-lansing.ppp <- ppp(lansing$x, lansing$y, win = lansing.win, 
+
+lansing.win <- st_read("../datafiles/lansing/lansing.shp", quiet = TRUE)
+
+lansing.ppp <- ppp(x = lansing$x, 
+                   y = lansing$y, 
+                   win = lansing.win, 
                    marks = lansing$species)
+
+```
+
+```{r, eval = FALSE}
+
 plot(lansing.ppp)
+
+```
+
+```{r, echo = FALSE, fig.width = 9}
+
+par(mar = c(1.0, 0.1, 2.0, 0.1))
+
+plot(lansing.ppp)
+
 ```
 
 The plot shows all the different marks (species) plotted together. We can access different marks, using the `split()` function, and can use this to analyze the distribution of any single species:
 
-```{r fig.keep='high'}
+```{r, eval = FALSE}
+
 plot(split(lansing.ppp), main = "All marks")
+
+```
+
+```{r, echo = FALSE, out.width = '100%'}
+
+bob <- split(lansing.ppp)
+
+mrk_names <- names(bob)
+
+bob <- unclass(bob)
+
+par(mfrow = c(2, 3), 
+    mar = c(0, 0, 1, 0), 
+    oma = c(1, 0, 3, 0))
+
+for(i in seq_along(mrk_names)){
+  
+  mrk_name <- mrk_names[[i]]
+  
+  plot(bob[[i]], main = "")
+  
+  mtext(text = mrk_name,
+        side = 3, 
+        line = -0.3, 
+        adj = 0.5)
+  
+}
+
+mtext("All Marks", cex = 1.75, side = 3, line = 1, outer = TRUE)
+
+```
+
+```{r}
+
 plot(split(lansing.ppp)$maple, "Maple trees")
+
 ```
 
 While these plots show some clear evidence of species that have quite different distributions, the `density()` function can be used to make this clearer:
 
-```{r fig.keep='high'}
-plot(density(split(lansing.ppp)), "Lansing density surfaces")
+```{r, eval = FALSE}
+
+plot(density(split(lansing.ppp)), main = "Lansing density surfaces")
+
+```
+
+```{r, echo = FALSE, out.width = '100%'}
+
+par(mfrow = c(2, 3), 
+    mar = c(0, 0, 1, 2), 
+    oma = c(1, 0, 3, 0))
+
+for(i in seq_along(mrk_names)){
+  
+  mrk_name <- mrk_names[[i]]
+  
+  dns <- density(bob[[i]])
+  
+  plot(dns, main = "")
+  
+  mtext(text = mrk_name,
+        side = 3, 
+        line = -0.3, 
+        adj = 0.4)
+  
+}
+
+mtext("Lansing density surfaces", cex = 1.75, side = 3, line = 1, outer = TRUE)
+
 ```
 
 To examine the co-occurrence of two marks or species, we can again use Ripley's $K$ function. We use the *cross* version: `Kcross()`, which examines pairwise differences between objects from the two classes. Again, we use the `envelope()` function to simulate random distributions, and specify the two species (marks) as $i$ and $j$ in the function:
 
-```{r cache=FALSE}
-lansing.kc <- envelope(lansing.ppp, Kcross, 
-                      i = "blackoak", j = "hickory",
-                      nsim = 99, verbose = FALSE)
+```{r}
+
+lansing.kc <- envelope(lansing.ppp, 
+                       Kcross, 
+                       i = "blackoak", 
+                       j = "hickory",
+                       nsim = 99, 
+                       verbose = FALSE)
+
 ```
 
 As before, we can plot the output as observed curves and the envelope of simulated random distributions. If the observed curve is above the envelope, this is evidence that the two species co-occur; if below then the two species tend to occur in different areas, suggesting some competitive interaction. If the observed curve is within the envelope, then the combined distribution is random.
 
-```{r fig.keep='high'}
+```{r}
+
 plot(lansing.kc)
+
 ```
 
 Try this again comparing species which have very different distributions, e.g. black oak and maple species. 
 
-## Point process models
+# Point process models
 
 Point process models can be fit to any `ppp` object using the `ppm()` function. This uses the set of observed points to model the variations in intensity of a point process, usually based on some set of covariates. This function takes as its first argument, a `ppp` object, and a set of covariates as the second argument. Note that the second argument is the same syntax as the right hand side of a linear model in R. We start by building a simple model of a homogeneous Poisson process (i.e. with no covariates):
 
 ```{r}
-fit0 <- ppm(bei.ppp, ~ 1)
+
+fit0 <- ppm(bei.ppp ~ 1)
+
 fit0
+
 ```
 
 This model returns a single parameter; the mean intensity for the region. As this is in log units, we can back convert as follows:
 
 ```{r}
+
 exp(coef(fit0))
+
 ```
 
 Telling us there is about 0.007th of a tree in each square meter. To check this is right, let's get the intensity directly from the `bei.ppp` object:
 
 ```{r}
+
 summary(bei.ppp)
+
 ```
 
 The following example models intensity as a second order polynomial function of the x and y coordinates of the objects.  The `polynom()` function expands a set of variables into their second (or $n^{th}$) order form (i.e. $x + y + x^2 + y^2 + x*y$ for second order coordinates).
 
-```{r results='hide'}
-fit1 <- ppm(bei.ppp, ~ polynom(x, y, 2))
+```{r}
+
+fit1 <- ppm(bei.ppp ~ polynom(x, y, 2))
+
 fit1
+
 ```
 
 And we can plot the fitted trend surface:
 
-```{r fig.keep='high'}
-plot(fit1, how = 'image', se = FALSE, pause = FALSE)
+```{r}
+
+plot(fit1, 
+     how = 'image', 
+     se = FALSE, 
+     pause = FALSE)
+
 ```
 
 Earlier, we saw a relationship between tree location and slope. We can use the same function (`ppm()`) to model the intensity of the distribution using slope values. For a point process model, it is important to have values of the covariate at locations away from the points, as well as at the, Here, we use the slope image (`bei.slope`), specified using the usual R model syntax.  
 
-```{r fig.keep='high'}
-fit2 <- ppm(bei.ppp, ~ bei.slope)
+```{r}
+
+fit2 <- ppm(bei.ppp ~ bei.slope)
+
 fit2
+
 ```
 
 The coefficient for the slope is about 5. Remember for regression models based on the log of the response variable, this is a multiplier, and reflects the increase in the intensity with each unit increase in slope. We can again plot the fitted trend surface:
 
-```{r fig.keep='high'}
-plot(fit2, how = 'image', se = FALSE, pause = FALSE)
+```{r}
+
+plot(fit2, 
+     how = 'image', 
+     se = FALSE, 
+     pause = FALSE)
+
 ```
 
-## Exercise
+# Exercise
 
 1. The zip file 'urkiola.zip' contains two shapefiles. The first *urkiola.shp* contains point locations of two species of tree (oak and birch) in a Spanish National Park. The second, *urkiolaWindow.shp*, contains the park boundary as a polygon. Code for reading in these files, and converting them into a point process object (`ppp`) is given below. Once you have obtained the `ppp` object:
     + Give the intensity (spatial density) of the combined set of two tree species by using the `summary()` function


### PR DESCRIPTION
After spending 3 grueling hours trying to fix the heinous facet plots produced by spatstat, I'm convinced now more than ever that spatstat should be rebuilt from the ground up and split into 20+ packages.

Changes:
1. Moved section headers up to h1 for CSS styling.
2. Removed vestigial LaTeX code.
3. Added white space to code chunks.
4. Increased area of marked point plot to make the different marks more visible.
5. Increased area of spatstat facet plots. Basically, I unclassed the split object and plotted each one separately.
